### PR TITLE
Adding 'js' to slappey language

### DIFF
--- a/src/TemplateGenerator.ts
+++ b/src/TemplateGenerator.ts
@@ -120,7 +120,7 @@ export class TemplateGenerator
   }
 
   async generateRegistry(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getRegistryFile() : getRegistryFileTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `registry.${extension}`);
@@ -128,7 +128,7 @@ export class TemplateGenerator
   }
 
   async generateBaseCommand(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getBaseCommand() : getBaseCommandTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `BaseCommand.${extension}`);
@@ -136,7 +136,7 @@ export class TemplateGenerator
   }
 
   async generateBaseEvent(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getBaseEvent() : getBaseEventTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `BaseEvent.${extension}`);
@@ -144,7 +144,7 @@ export class TemplateGenerator
   }
 
   async generateTestCommand(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getTestCommand() : getTestCommandTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `TestCommand.${extension}`);
@@ -152,7 +152,7 @@ export class TemplateGenerator
   }
 
   async generateReadyEvent(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getReadyEvent() : getReadyEventTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `ReadyEvent.${extension}`);
@@ -160,7 +160,7 @@ export class TemplateGenerator
   }
 
   async generateMessageEvent(filePath: string) {
-    const isJs = this.language === "javascript";
+    const isJs = ["javascript", "js"].includes(this.language!)
     const template = isJs ? getMessageEvent() : getMessageEventTS();
     const extension: FileExtension = isJs ? "js" : "ts";
     const file = path.join(filePath, `MessageEvent.${extension}`);
@@ -173,7 +173,7 @@ export class TemplateGenerator
     const filePath = path.join(categoryPath, fileName);
     const exists = await this.fileSystem.exists(filePath);
     if (!exists) {
-      const isJs = this.language === "javascript";
+      const isJs = ["javascript", "js"].includes(this.language!)
       const template = isJs
         ? getCommandTemplate(name, category)
         : getCommandTemplateTS(name, category);
@@ -196,7 +196,7 @@ export class TemplateGenerator
   }
 
   getTemplate(event: string) {
-    return this.language === "javascript" ? eventsJS[event] : eventsTS[event];
+    return ["javascript", "js"].includes(this.language!) ? eventsJS[event] : eventsTS[event];
   }
 
   static getTemplateGenerator(): TemplateGenerator {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -43,7 +43,7 @@ export class FileSystem implements FileSystemManager, Initializer {
   }
 
   async createEntryFile(filePath: string) {
-    const extension = this.language === "javascript" ? "js" : "ts";
+    const extension = ["javascript", "js"].includes(this.language!) ? "js" : "ts";
     const template = extension === "js" ? getMainFile() : getMainFileTS();
     return fs.writeFile(path.join(filePath, `index.${extension}`), template);
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -11,12 +11,12 @@ export const checkStructType = (arg: any) =>
   ["command", "event"].some((element) => element === arg);
 
 export const getCommandName = (name: string, language: Language) =>
-  language === "javascript"
+  ["javascript", "js"].includes(language)
     ? `${capitalize(name)}Command.js`
     : `${capitalize(name)}Command.ts`;
 
 export const getEventName = (name: string, language: Language) =>
-  language === "javascript"
+  ["javascript", "js"].includes(language)
     ? `${capitalize(name)}Event.js`
     : `${capitalize(name)}Event.ts`;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,6 @@
 export type Action = "new" | "gen";
 export type CLIArguments = [option: Action, data: string];
-export type Language = "typescript" | "javascript";
+export type Language = "typescript" | "javascript" | FileExtension;
 export type PackageManagerType = "npm" | "yarn";
 export type FileExtension = "js" | "ts";
 export type StructureType = "command" | "event";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
+    "lib": [
+      "dom",
+      "es7"
+   ],
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "outDir": "./lib" /* Redirect output structure to the directory. */,


### PR DESCRIPTION
fix to #43 

It is not a really important change as it allows users with v.2.0.0 `slappey.json` to still generate commands/events. 

The main difference is the change from ``language === "javascript"`` to allow "js" by doing so ``["javascript", "js"].includes(language)``.
However, the target version for Typescript (**ES6**) doesn't support polyfills (`includes`) so I had to add the modules
```json
"lib": [
      "dom",
      "es7"
   ]
```