### PR TITLE
Update template.ts

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -232,7 +232,7 @@ export function getMessageEvent() {
 
 module.exports = class MessageEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
   
   async run(client, message) {
@@ -258,7 +258,7 @@ import DiscordClient from '../../client/client';
 
 export default class MessageEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
 
   async run(client: DiscordClient, message: Message) {


### PR DESCRIPTION
These changes fixed the error "WARN: 'message' event deprecated" after sending a command and the bot replies. The warning did not error out the bot in any way, I just like a clean bot. 😄