### PR TITLE
Allow non-command/event files to be put in the same dir

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -76,7 +76,7 @@ export async function registerCommands(client: DiscordClient, dir: string = '') 
   for (const file of files) {
     const stat = await fs.lstat(path.join(filePath, file));
     if (stat.isDirectory()) registerCommands(client, path.join(dir, file));
-    if (file.endsWith('.js') || file.endsWith('.ts')) {
+    if (file.endsWith('Command.js') || file.endsWith('Command.ts')) {
       const { default: Command } = await import(path.join(dir, file));
       const command = new Command();
       client.commands.set(command.getName(), command);
@@ -93,7 +93,7 @@ export async function registerEvents(client: DiscordClient, dir: string = '') {
   for (const file of files) {
     const stat = await fs.lstat(path.join(filePath, file));
     if (stat.isDirectory()) registerEvents(client, path.join(dir, file));
-    if (file.endsWith('.js') || file.endsWith('.ts')) {
+    if (file.endsWith('Event.js') || file.endsWith('Event.ts')) {
       const { default: Event } = await import(path.join(dir, file));
       const event = new Event();
       client.events.set(event.getName(), event);


### PR DESCRIPTION
This will allow helper ts and js files to be put in the same directory as the event and command files without the "... is not a constructor".
In other words, it allows this file structure to work:
![image](https://user-images.githubusercontent.com/66224939/136633324-13d82271-6004-4f5b-a410-29e7c364cef0.png)

This will require command and event files to end in `Command.ts` and `Event.ts` respectively, which slappey already does.