### PR TITLE
Changed class name message to messageCreate

### DIFF
--- a/__tests__/__snapshots__/Snapshots.spec.ts.snap
+++ b/__tests__/__snapshots__/Snapshots.spec.ts.snap
@@ -23,7 +23,7 @@ module.exports = class ChannelDeleteEvent extends BaseEvent {
   }
   
   async run(client, channel) {
-    
+    console.log(channel.name + ' was deleted.');
   }
 }
 "
@@ -288,13 +288,13 @@ module.exports = class GuildUpdateEvent extends BaseEvent {
 exports[`Generating Event Snapshots should generate all Javascript Event Files 22`] = `
 "// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-message
 const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class MessageEvent extends BaseEvent {
+module.exports = class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
   
   async run(client, message) {
-    console.log(client.usert.tag + ' has logged in.');
+    
   }
 }"
 `;
@@ -1250,9 +1250,9 @@ import { Message } from 'discord.js';
 import BaseEvent from '../utils/structures/BaseEvent';
 import DiscordClient from '../client/client';
 
-export default class MessageEvent extends BaseEvent {
+export default class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
   
   async run(client: DiscordClient, message: Message) {
@@ -2047,7 +2047,7 @@ module.exports = class BanCommand extends BaseCommand {
     super('Ban', 'mod', []);
   }
 
-  run(client, message, args) {
+  asnyc run(client, message, args) {
     message.channel.send('Ban command works');
   }
 }"
@@ -2108,9 +2108,9 @@ const client = new DiscordClient({});
 exports[`Templates should match getMessageEvent 1`] = `
 "const BaseEvent = require('../../utils/structures/BaseEvent');
 
-module.exports = class MessageEvent extends BaseEvent {
+module.exports = class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
   
   async run(client, message) {
@@ -2134,9 +2134,9 @@ exports[`Templates should match getMessageEventTS 1`] = `
 import { Message } from 'discord.js';
 import DiscordClient from '../../client/client';
 
-export default class MessageEvent extends BaseEvent {
+export default class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
 
   async run(client: DiscordClient, message: Message) {

--- a/src/TemplateGenerator.ts
+++ b/src/TemplateGenerator.ts
@@ -159,7 +159,7 @@ export class TemplateGenerator
     await this.fileSys.createFile(file, template);
   }
 
-  async generateMessageEvent(filePath: string) {
+  async generateMessageCreateEvent(filePath: string) {
     const isJs = this.language === 'javascript';
     const template = isJs ? getMessageCreateEvent() : getMessageCreateEventTS();
     const extension: FileExtension = isJs ? 'js' : 'ts';

--- a/src/TemplateGenerator.ts
+++ b/src/TemplateGenerator.ts
@@ -14,8 +14,8 @@ import {
   getBaseEventTS,
   getCommandTemplate,
   getCommandTemplateTS,
-  getMessageEvent,
-  getMessageEventTS,
+  getMessageCreateEvent,
+  getMessageCreateEventTS,
   getReadyEvent,
   getReadyEventTS,
   getRegistryFile,
@@ -57,7 +57,7 @@ export class TemplateGenerator
     await this.generateBaseEvent(structures);
     await this.generateTestCommand(test);
     await this.generateReadyEvent(ready);
-    await this.generateMessageEvent(message);
+    await this.generateMessageCreateEvent(message);
   }
 
   getPaths(srcPath: string) {
@@ -68,7 +68,7 @@ export class TemplateGenerator
     const client = path.join(srcPath, 'client');
     const test = path.join(commands, 'test');
     const ready = path.join(events, 'ready');
-    const message = path.join(events, 'message');
+    const message = path.join(events, 'messageCreate');
     return {
       commands,
       utils,
@@ -116,7 +116,7 @@ export class TemplateGenerator
     await this.fileSys.createDirectory(ready);
     this.logger.success('Created ReadyEvent Directory');
     await this.fileSys.createDirectory(message);
-    this.logger.success('Created MessageEvent Directory');
+    this.logger.success('Created MessageCreateEvent Directory');
   }
 
   async generateRegistry(filePath: string) {
@@ -161,9 +161,9 @@ export class TemplateGenerator
 
   async generateMessageEvent(filePath: string) {
     const isJs = this.language === 'javascript';
-    const template = isJs ? getMessageEvent() : getMessageEventTS();
+    const template = isJs ? getMessageCreateEvent() : getMessageCreateEventTS();
     const extension: FileExtension = isJs ? 'js' : 'ts';
-    const file = path.join(filePath, `MessageEvent.${extension}`);
+    const file = path.join(filePath, `MessageCreateEvent.${extension}`);
     await this.fileSys.createFile(file, template);
   }
 

--- a/src/templates/events.ts
+++ b/src/templates/events.ts
@@ -351,7 +351,7 @@ module.exports = class ReadyEvent extends BaseEvent {
 }`,
   messageCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-message
 const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class MessageEvent extends BaseEvent {
+module.exports = class MessageCreateEvent extends BaseEvent {
   constructor() {
     super('messageCreate');
   }

--- a/src/templates/events.ts
+++ b/src/templates/events.ts
@@ -35,54 +35,6 @@ module.exports = class ApplicationCommandUpdateEvent extends BaseEvent {
   }
 }
   `,
-  guildMemberAvailable: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberAvailable
-const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class GuildMemberAvailableEvent extends BaseEvent {
-  constructor() {
-    super('guildMemberAvailable');
-  }
-
-  async run(client, member) {
-
-  }
-}
-  `,
-  guildMembersChunk: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMembersChunk
-const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class GuildMemberChunksEvent extends BaseEvent {
-  constructor() {
-    super('guildMembersChunk');
-  }
-
-  async run(client, members, guild, chunk) {
-
-  }
-}
-  `,
-  interactionCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-interactionCreate
-const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class InteractionCreateEvent extends BaseEvent {
-  constructor() {
-    super('interactionCreate');
-  }
-
-  async run(client, interaction) {
-
-  }
-}
-  `,
-  invalidRequestWarning: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-invalidRequestWarning
-const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class InvalidRequestWarningEvent extends BaseEvent {
-  constructor() {
-    super('invalidRequestWarning');
-  }
-
-  async run(client, invalidRequestWarningData) {
-
-  }
-}
-  `,
   channelCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-channelCreate
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class ChannelCreateEvent extends BaseEvent {
@@ -102,7 +54,7 @@ module.exports = class ChannelDeleteEvent extends BaseEvent {
   }
   
   async run(client, channel) {
-    
+    console.log(channel.name + ' was deleted.');
   }
 }
 `,
@@ -192,7 +144,7 @@ module.exports = class GuildBanAddEvent extends BaseEvent {
     super('guildBanAdd');
   }
   
-  async run(client, guildBan) {
+  async run(client, ban) {
     
   }
 }`,
@@ -203,7 +155,7 @@ module.exports = class GuildBanRemoveEvent extends BaseEvent {
     super('guildBanRemove');
   }
   
-  async run(client, guildBan) {
+  async run(client, ban) {
     
   }
 }`,
@@ -251,6 +203,18 @@ module.exports = class GuildMemberAddEvent extends BaseEvent {
     
   }
 }`,
+  guildMemberAvailable: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberAvailable
+const BaseEvent = require('../utils/structures/BaseEvent');
+module.exports = class GuildMemberAvailableEvent extends BaseEvent {
+  constructor() {
+    super('guildMemberAvailable');
+  }
+
+  async run(client, member) {
+
+  }
+}
+  `,
   guildMemberRemove: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberRemove
   const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class GuildMemberRemoveEvent extends BaseEvent {
@@ -273,17 +237,29 @@ module.exports = class GuildMemberSpeakingEvent extends BaseEvent {
     
   }
 }`,
-  guildMemberUpdate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberUpdate
+  guildMembersChunk: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMembersChunk
 const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class GuildMemberUpdateEvent extends BaseEvent {
+module.exports = class GuildMemberChunksEvent extends BaseEvent {
   constructor() {
-    super('guildMemberUpdate');
+    super('guildMembersChunk');
   }
-  
-  async run(client, oldMember, newMember) {
+
+  async run(client, members, guild, chunk) {
+
+  }
+}
+  `,
+  guildMemberUpdate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberUpdate
+  const BaseEvent = require('../utils/structures/BaseEvent');
+  module.exports = class GuildMemberUpdateEvent extends BaseEvent {
+    constructor() {
+      super('guildMemberUpdate');
+    }
     
-  }
-}`,
+    async run(client, oldMember, newMember) {
+      
+    }
+  }`,
   guildUnavailable: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildUnavailable
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class GuildUnavailableEvent extends BaseEvent {
@@ -306,17 +282,41 @@ module.exports = class GuildUpdateEvent extends BaseEvent {
     
   }
 }`,
-  invalidated: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-invalidated
+  interactionCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-interactionCreate
 const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class InvalidatedEvent extends BaseEvent {
+module.exports = class InteractionCreateEvent extends BaseEvent {
   constructor() {
-    super('invalidated');
+    super('interactionCreate');
   }
-  
-  async run(client) {
+
+  async run(client, interaction) {
+
+  }
+}
+  `,
+  invalidated: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-invalidated
+  const BaseEvent = require('../utils/structures/BaseEvent');
+  module.exports = class InvalidatedEvent extends BaseEvent {
+    constructor() {
+      super('invalidated');
+    }
     
+    async run(client) {
+      
+    }
+  }`,
+  invalidRequestWarning: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-invalidRequestWarning
+const BaseEvent = require('../utils/structures/BaseEvent');
+module.exports = class InvalidRequestWarningEvent extends BaseEvent {
+  constructor() {
+    super('invalidRequestWarning');
   }
-}`,
+
+  async run(client, invalidRequestWarningData) {
+
+  }
+}
+  `,
   inviteCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-inviteCreate
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class EmojiDeleteEvent extends BaseEvent {
@@ -339,16 +339,6 @@ module.exports = class InviteDeleteEvent extends BaseEvent {
     
   }
 }`,
-  ready: `// const BaseEvent = require('../utils/structures/BaseEvent');
-module.exports = class ReadyEvent extends BaseEvent {
-  constructor() {
-    super('ready');
-  }
-  
-  async run(client) {
-    console.log(client.user.tag + ' has logged in.');
-  }
-}`,
   messageCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-message
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class MessageCreateEvent extends BaseEvent {
@@ -357,7 +347,7 @@ module.exports = class MessageCreateEvent extends BaseEvent {
   }
   
   async run(client, message) {
-    console.log(client.user.tag + ' has logged in.');
+    
   }
 }`,
   messageDelete: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-messageDelete
@@ -400,7 +390,7 @@ module.exports = class MessageReactionRemoveEvent extends BaseEvent {
     super('messageReactionRemove');
   }
   
-  async run(client, reaction, user) {
+  async run(client, message, reaction, user) {
     
   }
 }`,
@@ -408,10 +398,10 @@ module.exports = class MessageReactionRemoveEvent extends BaseEvent {
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class MessageReactionRemoveAllEvent extends BaseEvent {
   constructor() {
-    super('ready');
+    super('messageReactionRemoveAll');
   }
   
-  async run(client, message) {
+  async run(client, message, reaction, user) {
     
   }
 }`,
@@ -459,6 +449,16 @@ module.exports = class RateLimitEvent extends BaseEvent {
     
   }
 }`,
+  ready: `// const BaseEvent = require('../utils/structures/BaseEvent');
+module.exports = class ReadyEvent extends BaseEvent {
+  constructor() {
+    super('ready');
+  }
+  
+  async run(client) {
+    console.log(client.user.tag + ' has logged in.');
+  }
+}`,
   roleCreate: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-roleCreate
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class RoleCreateEvent extends BaseEvent {
@@ -492,7 +492,7 @@ module.exports = class RoleUpdateEvent extends BaseEvent {
     
   }
 }`,
-  shardDisconnect: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-emojiUpdate
+  shardDisconnect: `// https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-shardDisconnect
 const BaseEvent = require('../utils/structures/BaseEvent');
 module.exports = class ShardDisconnectEvent extends BaseEvent {
   constructor() {
@@ -676,7 +676,7 @@ module.exports = class ThreadUpdateEvent extends BaseEvent {
     super('threadUpdate');
   }
 
-  async run(client, oldMembers, newMembers) {
+  async run(client, oldThread, newThread) {
 
   }
 }`,

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -227,12 +227,12 @@ export default class ReadyEvent extends BaseEvent {
 }`;
 }
 
-export function getMessageEvent() {
+export function getMessageCreateEvent() {
   return `const BaseEvent = require('../../utils/structures/BaseEvent');
 
-module.exports = class MessageEvent extends BaseEvent {
+module.exports = class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
   
   async run(client, message) {
@@ -251,14 +251,14 @@ module.exports = class MessageEvent extends BaseEvent {
 }`;
 }
 
-export function getMessageEventTS() {
+export function getMessageCreateEventTS() {
   return `import BaseEvent from '../../utils/structures/BaseEvent';
 import { Message } from 'discord.js';
 import DiscordClient from '../../client/client';
 
-export default class MessageEvent extends BaseEvent {
+export default class MessageCreateEvent extends BaseEvent {
   constructor() {
-    super('message');
+    super('messageCreate');
   }
 
   async run(client: DiscordClient, message: Message) {

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -194,7 +194,7 @@ export default abstract class BaseEvent {
   constructor(private name: string) { }
 
   getName(): string { return this.name; }
-  abstract run(client: DiscordClient, ...args: any): void;
+  abstract async run(client: DiscordClient, ...args: any): void;
 }
 `;
 }
@@ -314,7 +314,7 @@ module.exports = class ${capitalize(name)}Command extends BaseCommand {
     super('${name}', '${category}', []);
   }
 
-  run(client, message, args) {
+  async run(client, message, args) {
     message.channel.send('${name} command works');
   }
 }`;

--- a/src/templates/tsevents.ts
+++ b/src/templates/tsevents.ts
@@ -423,7 +423,7 @@ import { Message } from 'discord.js';
 import BaseEvent from '../utils/structures/BaseEvent';
 import DiscordClient from '../client/client';
 
-export default class CreateMessageEvent extends BaseEvent {
+export default class MessageCreateEvent extends BaseEvent {
   constructor() {
     super('messageCreate');
   }

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -35,7 +35,7 @@ export interface ProjectTemplateGenerator {
   generateDirectories(filePath: string): void;
   generateTestCommand(filePath: string): void;
   generateReadyEvent(filePath: string): void;
-  generateMessageEvent(filePath: string): void;
+  generateMessageCreateEvent(filePath: string): void;
   generateClient(filePath: string): void;
 }
 


### PR DESCRIPTION
revises PR #99 and PR #106. These changes will be used globally so that slappey will pull messageCreate correctly instead of only the template generator. Made it its own class instead of a constructor. I will close #99 and #106 now. Also fixed typos in events.ts and placed in chronological order according to Discord.js Docs.