### PR TITLE
Added Support for PNPM 

### DIFF
--- a/__tests__/Manager.spec.ts
+++ b/__tests__/Manager.spec.ts
@@ -109,7 +109,7 @@ describe("PackageManager", () => {
   });
 
   it("should call installTypescript with npm", async () => {
-    const cmd = "npm i -D typescript";
+    const cmd = "npm add -D typescript";
     config.manager = "npm";
     manager.initialize(config, fakePath);
     manager.installTypescript();
@@ -121,7 +121,7 @@ describe("PackageManager", () => {
   });
 
   it("should call installDiscordJS with npm", async () => {
-    const cmd = "npm i discord.js@latest";
+    const cmd = "npm add discord.js@latest";
     manager.installDiscordJS();
     expect(child_process.execSync).toHaveBeenCalledTimes(1);
     expect(child_process.execSync).toHaveBeenCalledWith(cmd, {
@@ -150,7 +150,7 @@ describe("PackageManager", () => {
     });
   });
   it("should call installNodemon with npm", async () => {
-    const cmd = "npm i -D nodemon";
+    const cmd = "npm add -D nodemon";
     config.manager = "npm";
     manager.initialize(config, fakePath);
     manager.installNodemon();
@@ -161,7 +161,7 @@ describe("PackageManager", () => {
     });
   });
   it("should call installNodeTypes with npm", async () => {
-    const cmd = "npm i -D @types/node";
+    const cmd = "npm add -D @types/node";
     manager.installNodeTypes();
     expect(child_process.execSync).toHaveBeenCalledTimes(1);
     expect(child_process.execSync).toHaveBeenCalledWith(cmd, {

--- a/__tests__/Manager.spec.ts
+++ b/__tests__/Manager.spec.ts
@@ -31,19 +31,23 @@ describe("PackageManager", () => {
   it("should call setup when manager is set with yarn", async () => {
     jest.spyOn(manager, "initializeYarn").mockImplementation(() => {});
     jest.spyOn(manager, "initializeNPM").mockImplementation(() => {});
+    jest.spyOn(manager, "initializePNPM").mockImplementation(() => {});
     await manager.setup();
     expect(manager.initializeYarn).toHaveBeenCalled();
     expect(manager.initializeNPM).not.toHaveBeenCalled();
+    expect(manager.initializePNPM).not.toHaveBeenCalled();
   });
 
   it("should call setup with initializeNPM", async () => {
     jest.spyOn(manager, "initializeNPM").mockImplementation(() => {});
+    jest.spyOn(manager, "initializePNPM").mockImplementation(() => {});
     jest.spyOn(manager, "initializeYarn").mockImplementation(() => {});
     config.manager = "npm";
     manager.initialize(config, fakePath);
     await manager.setup();
     expect(manager.initializeNPM).toHaveBeenCalled();
     expect(manager.initializeYarn).not.toHaveBeenCalled();
+    expect(manager.initializePNPM).not.toHaveBeenCalled();
   });
 
   it("call initializeNPM", () => {
@@ -63,6 +67,18 @@ describe("PackageManager", () => {
     manager.initializeYarn();
     expect(child_process.execSync).toHaveBeenCalledTimes(1);
     expect(child_process.execSync).toHaveBeenCalledWith("yarn init -y", {
+      cwd: fakePath,
+    });
+    expect(manager.installDependencies).toHaveBeenCalledTimes(1);
+  });
+
+  it("call initializePNPM", () => {
+    jest.spyOn(manager, "installDependencies").mockImplementation(() => {});
+    config.manager = "pnpm";
+    manager.initialize(config, fakePath);
+    manager.initializePNPM();
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execSync).toHaveBeenCalledWith("pnpm init -y", {
       cwd: fakePath,
     });
     expect(manager.installDependencies).toHaveBeenCalledTimes(1);
@@ -108,6 +124,16 @@ describe("PackageManager", () => {
     });
   });
 
+  it("should call installTypescript with pnpm", async () => {
+    const cmd = "pnpm add  -D typescript";
+    manager.installTypescript();
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execSync).toHaveBeenCalledWith(cmd, {
+      cwd: fakePath,
+      stdio: "ignore",
+    });
+  });
+
   it("should call installTypescript with npm", async () => {
     const cmd = "npm add -D typescript";
     config.manager = "npm";
@@ -129,6 +155,7 @@ describe("PackageManager", () => {
       stdio: "ignore",
     });
   });
+
   it("should call installDiscordJS with yarn", async () => {
     const cmd = "yarn add discord.js@latest";
     config.manager = "yarn";
@@ -140,6 +167,19 @@ describe("PackageManager", () => {
       stdio: "ignore",
     });
   });
+
+  it("should call installDiscordJS with pnpm", async () => {
+    const cmd = "pnpm add  discord.js@latest";
+    config.manager = "pnpm";
+    manager.initialize(config, fakePath);
+    manager.installDiscordJS();
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execSync).toHaveBeenCalledWith(cmd, {
+      cwd: fakePath,
+      stdio: "ignore",
+    });
+  });
+
   it("should call installNodemon with yarn", async () => {
     const cmd = "yarn add -D nodemon";
     manager.installNodemon();
@@ -149,6 +189,17 @@ describe("PackageManager", () => {
       stdio: "ignore",
     });
   });
+
+  it("should call installNodemon with pnpm", async () => {
+    const cmd = "pnpm add  -D nodemon";
+    manager.installNodemon();
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execSync).toHaveBeenCalledWith(cmd, {
+      cwd: fakePath,
+      stdio: "ignore",
+    });
+  });
+
   it("should call installNodemon with npm", async () => {
     const cmd = "npm add -D nodemon";
     config.manager = "npm";
@@ -160,6 +211,7 @@ describe("PackageManager", () => {
       stdio: "ignore",
     });
   });
+
   it("should call installNodeTypes with npm", async () => {
     const cmd = "npm add -D @types/node";
     manager.installNodeTypes();
@@ -169,9 +221,22 @@ describe("PackageManager", () => {
       stdio: "ignore",
     });
   });
+
   it("should call installNodeTypes with yarn", async () => {
     const cmd = "yarn add -D @types/node";
     config.manager = "yarn";
+    manager.initialize(config, fakePath);
+    manager.installNodeTypes();
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execSync).toHaveBeenCalledWith(cmd, {
+      cwd: fakePath,
+      stdio: "ignore",
+    });
+  });
+
+  it("should call installNodeTypes with pnpm", async () => {
+    const cmd = "pnpm add  -D @types/node";
+    config.manager = "pnpm";
     manager.initialize(config, fakePath);
     manager.installNodeTypes();
     expect(child_process.execSync).toHaveBeenCalledTimes(1);

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -32,7 +32,7 @@ export class PackageManager implements Initializer {
 
   public createTsconfig() {
     return execSync(
-      `${this.config?.manager} run tsc --init --resolveJsonModule --target es6`,
+      `${this.config?.manager === 'npm' ? 'npx' : this.config?.manager} tsc --init --resolveJsonModule --target es6`,
       { cwd: this.filePath }
     );
   }

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -10,7 +10,7 @@ export class PackageManager implements Initializer {
   async initialize(config: SlappeyConfig, filePath: string): Promise<void> {
     this.config = config;
     this.filePath = filePath;
-    this.prefix = this.config.manager === 'npm' ? 'npm i' : 'yarn add';
+    this.prefix = `${this.config.manager} add`;
   }
 
   async setup() {

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -30,6 +30,11 @@ export class PackageManager implements Initializer {
     return this.installDependencies();
   }
 
+  public initializePNPM() {
+    execSync(`${this.config?.manager} init -y`, { cwd: this.filePath });
+    return this.installDependencies();
+  }
+
   public createTsconfig() {
     return execSync(
       `${this.config?.manager === 'npm' ? 'npx' : this.config?.manager} tsc --init --resolveJsonModule --target es6`,

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -15,9 +15,12 @@ export class PackageManager implements Initializer {
 
   async setup() {
     if (!this.config) throw new Error('Config Not Initialized.');
-    return this.config.manager === 'npm'
-      ? this.initializeNPM()
-      : this.initializeYarn();
+    const initialize = {
+      npm: this.initializeNPM(),
+      yarn: this.initializeYarn(),
+      pnpm: this.initializePNPM(),
+    }
+    return initialize[this.config.manager];
   }
 
   public initializeNPM() {

--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -76,6 +76,10 @@ export const packageManager: Array<PromptObject> = [
         value: 'yarn',
       },
       {
+        title: 'pnpm',
+        value: 'pnpm',
+      },
+      {
         title: 'npm',
         value: 'npm',
       },

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,7 +1,7 @@
 export type Action = 'new' | 'gen';
 export type CLIArguments = [option: Action, data: string];
 export type Language = 'typescript' | 'javascript';
-export type PackageManagerType = 'npm' | 'yarn';
+export type PackageManagerType = 'npm' | 'yarn' | 'pnpm';
 export type FileExtension = 'js' | 'ts';
 export type StructureType = 'command' | 'event';
 export type Credentials = {


### PR DESCRIPTION
This is in response to issues https://github.com/stuyy/slappey/issues/102#issue-1014510172 https://github.com/stuyy/slappey/issues/101#issue-1014111566

# Added support for [Pnpm](https://pnpm.io/)
With the growing popularity of pnpm I wanted to add support. I also fixed the issue with NPM when creating a new typescript bot


# Bug Fixes
- [x] [Fix](https://github.com/stuyy/slappey/commit/b1baaed6d88277af656eb42e751c19035e6a8d2b) npm "Missing script: tsc" when creating new typescript bot

# Changes

- [x] Change [NPM install](https://github.com/stuyy/slappey/commit/174e55435abaeb7c5ff7820b5b2bf852751c7852) to NPM add which is a supported alias since [v6](https://docs.npmjs.com/cli/v6/commands/npm-install)
- [x] Update [NPM tests](https://github.com/stuyy/slappey/commit/f590b00ec554b7fab5987539e6a3c78c4aba5a68) to reflect change
- [x] Change [initializer](https://github.com/stuyy/slappey/commit/48814f4d87186ea067d23647b3ea8d6ff651bc63) selection to support pnpm option 

# Additions

- [x] Add pnpm prompt and type
- [x] Add pnpm [initializer](https://github.com/stuyy/slappey/commit/0fb4450f1a6efc975a62ca591b6e2663f265b012)
- [x] Added [pnpm tests](https://github.com/stuyy/slappey/commit/f1eba298a41af69941840b310db913955b09ce9d)